### PR TITLE
Update: gpio-keys.kl

### DIFF
--- a/keylayout/gpio-keys.kl
+++ b/keylayout/gpio-keys.kl
@@ -27,4 +27,4 @@
 
 key 115   VOLUME_UP
 key 114   VOLUME_DOWN
-key 377   INFO
+key 377   CAMERA


### PR DESCRIPTION
Map extra button to CAMERA. Long pressing the button, below "vol-" key, will open Camera app by default. Quick pressing button while Camera app is open will snap picture.